### PR TITLE
Clearer error message/context.

### DIFF
--- a/lib/detector.js
+++ b/lib/detector.js
@@ -71,7 +71,7 @@ Detector.prototype._validateFilePaths = function() {
 
   return new Promise(function(resolve, reject) {
     if (!(self._filePaths instanceof Array) || !self._filePaths.length) {
-      throw new Error('filePaths must be a non-empty array of paths');
+      throw new Error('filePaths must be a non-empty array of paths. Buddy could not find any JS files to analyze.');
     }
 
     resolve();

--- a/spec/unit/detectorSpec.js
+++ b/spec/unit/detectorSpec.js
@@ -65,7 +65,7 @@ describe('Detector', function() {
       var detector = new Detector();
       detector.run().catch(function(err) {
         expect(err).to.be.an(Error);
-        expect(err.message).to.be('filePaths must be a non-empty array of paths');
+        expect(err.message).to.be('filePaths must be a non-empty array of paths. Buddy could not find any JS files to analyze.');
         done();
       });
     });


### PR DESCRIPTION
This happens, for example, if you run `buddy .` in a directory
that contains no JavaScript files.
