### PR TITLE
seperate concerns between file parse and code parse

### DIFF
--- a/lib/detector.js
+++ b/lib/detector.js
@@ -51,7 +51,11 @@ Detector.prototype.run = function(fn) {
 
     var promises = [];
     self._filePaths.forEach(function(filePath) {
-      promises.push(self._parseFile(filePath));
+      var promise = self._readFileAsync(filePath).then(function(contents) {
+        self._parseContents(filePath, contents);
+      });
+
+      promises.push(promise);
     });
 
     // Parse the files
@@ -82,6 +86,20 @@ Detector.prototype._validateFilePaths = function() {
 };
 
 /**
+ * _readFileAsync
+ * Reads a given filePath and return a promise with contents when resolved
+ *
+ * @private
+ *
+ * @param filePath
+ * @return {Promise}
+ */
+Detector.prototype._readFileAsync = function(filePath) {
+  var opts = {encoding: 'utf8'};
+  return fs.readFileAsync(filePath, opts);
+};
+
+/**
  * Retrieves the given file's contents and invoked acorn's parser to build a
  * syntax tree conforming to the Mozilla Parser API. Each node includes its
  * location, as well as the source file. The AST is then searched. Returns a
@@ -89,14 +107,13 @@ Detector.prototype._validateFilePaths = function() {
  *
  * @private
  *
- * @param {string} filePath The path to the file to parse
+ * @param {string} filePath The original filepath
+ * @param {string} contents The contents to parse
  *
  * @returns {Promise}
  */
-Detector.prototype._parseFile = function(filePath) {
+Detector.prototype._parseContents = function(filePath, contents) {
   var self = this;
-  var opts = {encoding: 'utf8'};
-
   var commentHandler = function(block, text, startoff, endoff, start) {
     if (text.indexOf('buddy ignore:line') !== -1) {
       self._ignoredLines.push(start.line);
@@ -107,17 +124,15 @@ Detector.prototype._parseFile = function(filePath) {
     }
   };
 
-  return fs.readFileAsync(filePath, opts).then(function(contents) {
-    var syntaxTree = acorn.parse(contents, {
-      ecmaVersion: 6,
-      allowReturnOutsideFunction: true,
-      locations: true,
-      sourceFile: filePath,
-      onComment: commentHandler
-    });
-
-    self._detectMagicNumbers(syntaxTree, contents);
+  var syntaxTree = acorn.parse(contents, {
+    ecmaVersion: 6,
+    allowReturnOutsideFunction: true,
+    locations: true,
+    sourceFile: filePath,
+    onComment: commentHandler
   });
+
+  return this._detectMagicNumbers(syntaxTree, contents);
 };
 
 /**


### PR DESCRIPTION
A common use case is to only use contents parsing instead of file path parsing. This patch separates concerns between reading file path and parsing contents.
