### PR TITLE
Add Related Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,3 +186,8 @@ var MINUTE = 60 * SECOND;
 var HOUR = 60 * MINUTE;
 // buddy ignore:end
 ```
+
+
+
+## Related
+- [Eslint's no-magic-numbers rule](https://eslint.org/docs/rules/no-magic-numbers)


### PR DESCRIPTION
# What is the change
Add "Related Section" referencing ESlint's magic number rule.

# Purpose of Change
1. Expose more people to the awesome-ness of no magic numbers.
2. [ESlint](https://eslint.org/docs/rules/no-magic-numbers) is constantly updating and maintaining their version of 'no magic numbers' linter rule that works with modern javascript & typescript. It seems like this repo hasn't been updated in a while.
3. Most people when they search 'no magic numbers' in javascript frequently land here. It would be nice for them to also know that it exists in ESlint as part of a core rule.

# Questions
Are you ok with putting a notice in the beginning of the README, indicating to user's that it's worth checking out ESlint's version in the spirit of getting more people exposed to 'no magic numbers'? 